### PR TITLE
Using Bicubic scaling for upsampling

### DIFF
--- a/src/main/scala/com/rdio/thor/ImageService.scala
+++ b/src/main/scala/com/rdio/thor/ImageService.scala
@@ -55,7 +55,7 @@ class ImageService(conf: Config) extends BaseImageService(conf) {
         Some {
           image.scale(downsampling).filter(BoxBlurFilter(downsampledHRadius, downsampledVRadius))
             .trim(1, 1, 1, 1) // Remove bleeded edges
-            .scaleTo(originalWidth, originalHeight, ScaleMethod.FastScale) // Scale up a bit to account for trim
+            .scaleTo(originalWidth, originalHeight, ScaleMethod.Bicubic) // Scale up a bit to account for trim
         }
       }
 
@@ -72,7 +72,7 @@ class ImageService(conf: Config) extends BaseImageService(conf) {
         Some {
           image.scale(downsampling).filter(BoxBlurFilter(downsampledHRadius, downsampledVRadius))
             .trim(1, 1, 1, 1) // Remove bleeded edges
-            .scaleTo(originalWidth, originalHeight, ScaleMethod.FastScale) // Scale up a bit to account for trim
+            .scaleTo(originalWidth, originalHeight, ScaleMethod.Bicubic) // Scale up a bit to account for trim
         }
       }
 


### PR DESCRIPTION
I got a little too aggressive with FastScale and introduced some visual artifacts at small sizes.

Before:

![dev](https://cloud.githubusercontent.com/assets/226553/3319206/ee2cf9fa-f71d-11e3-8d3c-fad7902b5295.jpeg)

After:

![local](https://cloud.githubusercontent.com/assets/226553/3319207/ef7cb174-f71d-11e3-8ca0-88ae5f3d6fd9.jpeg)
