### PR TITLE
Adding cover and fit filters

### DIFF
--- a/src/main/scala/com/rdio/thor/ImageRequest.scala
+++ b/src/main/scala/com/rdio/thor/ImageRequest.scala
@@ -224,7 +224,15 @@ class ImageRequest(
         Some(image.filter(RoundCornersFilter(radius)))
       }
 
-      case CoverNode(width, height) => Some(image.cover(width, height, ScaleMethod.Bicubic))
+      case CoverNode() => {
+        val (w, h) = getDimensions(completedLayers.lastOption, requestWidth, requestHeight)
+        Some(image.cover(w, h, ScaleMethod.Bicubic))
+      }
+
+      case FitNode() => {
+        val (w, h) = getDimensions(completedLayers.lastOption, requestWidth, requestHeight)
+        Some(image.fit(w, h, new Color(0, 0, 0, 0), ScaleMethod.Bicubic))
+      }
 
       case OverlayNode(overlay) => {
         getImage(overlay, completedLayers) match {

--- a/src/main/scala/com/rdio/thor/LayerParser.scala
+++ b/src/main/scala/com/rdio/thor/LayerParser.scala
@@ -35,7 +35,8 @@ case class RoundCornersNode(radius: Int) extends FilterNode
 case class RoundCornersPercentNode(radius: Float) extends FilterNode
 case class OverlayNode(overlay: ImageNode) extends FilterNode
 case class MaskNode(overlay: ImageNode, mask: ImageNode) extends FilterNode
-case class CoverNode(width: Int, height: Int) extends FilterNode
+case class CoverNode() extends FilterNode
+case class FitNode() extends FilterNode
 
 case class LayerNode(source: ImageNode, filter: FilterNode)
 
@@ -236,8 +237,13 @@ class LayerParser(requestWidth: Int, requestHeight: Int) extends JavaTokenParser
   }
 
   // cover filter
-  def cover: Parser[CoverNode] = "cover(" ~> pixels ~ "," ~ pixels <~ ")" ^^ {
-    case width ~ _ ~ height => CoverNode(width, height)
+  def cover: Parser[CoverNode] = "cover()" ^^ {
+    case _ => CoverNode()
+  }
+
+  // fit filter
+  def fit: Parser[FitNode] = "fit()" ^^ {
+    case _ => FitNode()
   }
 
   // all filters
@@ -245,6 +251,7 @@ class LayerParser(requestWidth: Int, requestHeight: Int) extends JavaTokenParser
     text | linear | boxblur | boxblurpercent |
     blur | scaleto | zoom | scale |
     grid | round | roundpercent | mask |
+    cover | fit |
     colorize | overlay | pad | padpercent |
     textpercent
 


### PR DESCRIPTION
![download](https://cloud.githubusercontent.com/assets/226553/3833313/1caf8b86-1da6-11e4-922a-d8a77a9914b0.jpeg)

http://localhost:8080/?l=a12345%3Acover()%3Bboxblur(10%25%2C10%25)%3Ba12345%3Around(100%25)%3Bpad(50%25)%3Bfit()%3B%241%3Aoverlay(%244)&w=600&h=338

`a12345:cover();boxblur(10%,10%);a12345:round(100%);pad(50%);fit();$1:overlay($4)`
